### PR TITLE
Set handlePanGesture method in header file of DBSphereView

### DIFF
--- a/DBSphereTagCloud/DBSphereView.h
+++ b/DBSphereTagCloud/DBSphereView.h
@@ -29,4 +29,6 @@
  */
 - (void)timerStop;
 
+- (void)handlePanGesture:(UIPanGestureRecognizer *)gesture;
+
 @end


### PR DESCRIPTION
It's necessary for use this library as IBoutlet, the current version only add PanGesture on initWIthFrame method. Using DBSphereView with IBoutlet we need add pan gesture 'manually'.
