### PR TITLE
Attach gesture recognizer when init from storyboard

### DIFF
--- a/DBSphereTagCloud/DBSphereView.m
+++ b/DBSphereTagCloud/DBSphereView.m
@@ -26,6 +26,15 @@
     CADisplayLink *inertia;
 }
 
+- (id)initWithCoder:(NSCoder*)aDecoder
+{
+    if(self = [super initWithCoder:aDecoder]) {
+        UIPanGestureRecognizer *gesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
+        [self addGestureRecognizer:gesture];
+    }
+    return self;
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];


### PR DESCRIPTION
I prefer to initialize my `DBSphereView` through the Storyboard rather than initializing it programmatically as you do in your Demo but when I do so, the gesture recognizer isn't added. This PR fixes this.